### PR TITLE
menubar-toggle.rb 1.0.1 SHA update

### DIFF
--- a/menubar-toggle.rb
+++ b/menubar-toggle.rb
@@ -2,7 +2,7 @@ class MenubarToggle < Formula
   desc "Toggle the OSX menubar's autohide setting from the command-line."
   homepage "https://github.com/sxmichaels/menubar-toggle"
   url "https://github.com/sxmichaels/menubar-toggle/archive/1.0.1.tar.gz"
-  sha256 "2c60e4b751a8dbca621bfba2b1a9f1cfddf1f6b539b9b226179e60c36273f813"
+  sha256 "7803749b6da1fde073226d7a02f0cef5a41066cd2d88eaef7d775bf3246c0b13"
 
   def install
     system "./build"


### PR DESCRIPTION
Change SHA256 to: **7803749b6da1fde073226d7a02f0cef5a41066cd2d88eaef7d775bf3246c0b13**

```
==> Upgrading sxmichaels/tap/menubar-toggle
==> Downloading https://github.com/sxmichaels/menubar-toggle/archive/1.0.1.tar.gz
==> Downloading from https://codeload.github.com/sxmichaels/menubar-toggle/tar.gz
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: 2c60e4b751a8dbca621bfba2b1a9f1cfddf1f6b539b9b226179e60c36273f813
Actual: 7803749b6da1fde073226d7a02f0cef5a41066cd2d88eaef7d775bf3246c0b13
Archive: /Users/benc/Library/Caches/Homebrew/menubar-toggle-1.0.1.tar.gz
```
