### PR TITLE
Require swift, add LDFLAG path

### DIFF
--- a/menubar-toggle.rb
+++ b/menubar-toggle.rb
@@ -8,6 +8,7 @@ class MenubarToggle < Formula
   depends_on "swift"
 
   def install
+    ENV.append "LDFLAGS", "-L/usr/local/opt/swift/lib"
     system "swift build --configuration release"
     bin.install "./.build/release/menubar-toggle"
   end

--- a/menubar-toggle.rb
+++ b/menubar-toggle.rb
@@ -5,6 +5,7 @@ class MenubarToggle < Formula
   sha256 "318c3d2122c3acde1afaf2570a3e7b938cc80bff4761ecc4177b1d659e18edf3"
 
   depends_on :macos => :el_capitan
+  depends_on "swift"
 
   def install
     system "swift build --configuration release"


### PR DESCRIPTION
You may want to sit on this until I get 8.0 command line, if swift is shipped by default in it. Apple's `swift` git tree, still doesn't have 3.0 even on `HEAD`.

If we need to compile `swift`, this should do it.
